### PR TITLE
Add support for bare repositories

### DIFF
--- a/lib/git_stats/generator.rb
+++ b/lib/git_stats/generator.rb
@@ -18,7 +18,7 @@ module GitStats
 
 
     def validate_repo_path(repo_path)
-      raise ArgumentError, "#{repo_path} is not a git repository" unless Dir.exists?("#{repo_path}/.git")
+      raise ArgumentError, "#{repo_path} is not a git repository" unless (Dir.exists?("#{repo_path}/.git") || File.exists?("#{repo_path}/HEAD"))
     end
 
   end


### PR DESCRIPTION
I needed to create stats for bare repos hosted on the server. I've just changed the line in "git_stats-1.0.3/lib/git_stats/generator.rb" file in "validate_repo_path" method by adding check for "HEAD" file if ".git" folder does not exist:

``` ruby
    def validate_repo_path(repo_path)
      raise ArgumentError, "#{repo_path} is not a git repository" unless (Dir.exists?("#{repo_path}/.git") || File.exists?("#{repo_path}/HEAD"))
    end
```

Probably this could be done even better, however this works for me.
