### PR TITLE
Add commit range to the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ It browses the repository and outputs html page with statistics.
 
 ### Generator
 
-    $ git_stats repo_path output_directory
+    $ git_stats repo_path output_directory language_code first_commit_sha last_commit_sha 
     $ favorite_browser output_directory/index.html
 
 ### API usage example
 
-    > repo = GitStats::GitData::Repo.new(path: '.')
+    > repo = GitStats::GitData::Repo.new(path: '.', first_commit_sha: 'abcd1234', last_commit_sha: 'HEAD')
     > repo.authors
     => [...]
     > repo.commits

--- a/lib/git_stats/cli.rb
+++ b/lib/git_stats/cli.rb
@@ -4,12 +4,12 @@ require "git_stats"
 class GitStats::CLI
 
   def start(*args)
-    raise "Wrong number of arguments\nUsage: git_stats repo_path output_path <output_lang>" unless [2, 3].include? args.size
+    raise "Wrong number of arguments\nUsage: git_stats repo_path output_path <output_lang>" unless [2, 3, 4, 5].include? args.size
 
-    repo_path, out_path, lang = args
+    repo_path, out_path, lang, first_commit_sha, last_commit_sha = args
     I18n.locale = lang || :en
 
-    GitStats::Generator.new(repo_path, out_path) { |g|
+    GitStats::Generator.new(repo_path, out_path, first_commit_sha, last_commit_sha) { |g|
       g.add_command_observer { |command, result| puts "#{command}" }
     }.render_all
   end

--- a/lib/git_stats/generator.rb
+++ b/lib/git_stats/generator.rb
@@ -4,10 +4,10 @@ module GitStats
     delegate :add_command_observer, to: :@repo
     delegate :render_all, to: :@view
 
-    def initialize(repo_path, out_path)
+    def initialize(repo_path, out_path, first_commit_sha, last_commit_sha)
       validate_repo_path(repo_path)
 
-      @repo = GitData::Repo.new(path: repo_path)
+      @repo = GitData::Repo.new(path: repo_path, first_commit_sha: first_commit_sha, last_commit_sha: last_commit_sha)
       view_data = StatsView::ViewData.new(@repo)
       @view = StatsView::View.new(view_data, out_path)
 

--- a/lib/git_stats/git_data/repo.rb
+++ b/lib/git_stats/git_data/repo.rb
@@ -6,7 +6,7 @@ module GitStats
     class Repo
       include HashInitializable
 
-      attr_reader :path
+      attr_reader :path, :first_commit_sha, :last_commit_sha
 
       delegate :files, :files_by_extension, :files_by_extension_count, :lines_by_extension,
                :files_count, :binary_files, :text_files, :lines_count, to: :last_commit


### PR DESCRIPTION
This adds 4th and 5th optional CLI parameters that specifies the first
and last SHA commit to generate stats between.
The generator and repo classes were changed to take these as
initialisation parameters.
It would be nice to have the CLI take individual named optional
parameters, so that only first or last commit could be given and
without having to give the language.
