### PR TITLE
Gibberish Translator

### DIFF
--- a/lib/git_stats/git_data/blob.rb
+++ b/lib/git_stats/git_data/blob.rb
@@ -22,7 +22,7 @@ module GitStats
       end
 
       def binary?
-        repo.run("git cat-file blob #{self.sha} | grep -m 1 '^'") =~ /Binary file/
+        repo.run("git cat-file blob #{self.sha} | grep -m 1 '^'").force_encoding('ISO-8859-1').encode('utf-8', replace: nil) =~ /Binary file/
       end
 
       def to_s


### PR DESCRIPTION
Foreign characters cause the binary file check to fail.

This allows the code to accept those characters. 

I'm not a ruby dev, so if this needs to be changed, let me know.

Example of word that caused the failure: Präzisions

Tested and works.
