### PR TITLE
crashes when generate stats, is there any version requirement

### DIFF
--- a/lib/git_stats/stats_view/charts/chart.rb
+++ b/lib/git_stats/stats_view/charts/chart.rb
@@ -35,21 +35,25 @@ module GitStats
 
         def date_chart(params)
           common_options(params)
-          date_series(name: params[:title], data: params[:data])
+          series(date_series(name: params[:title], data: params[:data]))
         end
 
         def multi_date_chart(params)
           common_options(params)
           default_legend
           params[:data].each do |s|
-            date_series(s)
+            series(date_series(s))
           end
         end
 
         def date_column_chart(params)
-          date_chart(params)
-          data[0][:type] = 'column'
-          data[0][:dataGrouping] = {units: [['day', [1]], ['week', [1]]], forced: true}
+          common_options(params)
+          series(date_series(name: params[:title], data: params[:data]).merge(
+            {
+              type: 'column',
+              dataGrouping: {units: [['day', [1]], ['week', [1]]], forced: true}
+            }
+          ))
         end
 
         def default_legend
@@ -101,11 +105,11 @@ module GitStats
         end
 
         def date_series(params)
-          series(
+          {
               name: params[:name],
               type: "spline",
               data: Hash[params[:data]].fill_empty_days!.map { |date, value| [date.to_datetime.to_i * 1000, value] }.sort_by { |d| d[0] }
-          )
+          }
         end
 
         def column_chart(params)


### PR DESCRIPTION
git_stats generate -o stats 
git rev-list --pretty=format:'%h|%at|%ai|%aE' HEAD | grep -v commit
git shortlog -se HEAD
/Users/User/.rvm/gems/ruby-1.9.3-p194/gems/git_stats-1.0.9/lib/git_stats/stats_view/charts/chart.rb:51:in `date_column_chart': undefined method`[]=' for nil:NilClass (NoMethodError)
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/git_stats-1.0.9/lib/git_stats/stats_view/charts/activity_charts.rb:13:in `block in activity_by_date'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/git_stats-1.0.9/lib/git_stats/stats_view/charts/chart.rb:13:in`initialize'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/git_stats-1.0.9/lib/git_stats/stats_view/charts/activity_charts.rb:12:in `new'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/git_stats-1.0.9/lib/git_stats/stats_view/charts/activity_charts.rb:12:in`activity_by_date'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/git_stats-1.0.9/lib/git_stats/stats_view/charts/charts.rb:11:in `activity_by_date'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/git_stats-1.0.9/templates/activity/_activity.haml:24:in`block in singletonclass'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/git_stats-1.0.9/templates/activity/_activity.haml:65527:in `instance_eval'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/git_stats-1.0.9/templates/activity/_activity.haml:65527:in`singletonclass'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/git_stats-1.0.9/templates/activity/_activity.haml:65525:in `__tilt_70177236667600'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/tilt-1.4.1/lib/tilt/template.rb:170:in`call'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/tilt-1.4.1/lib/tilt/template.rb:170:in `evaluate'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/tilt-1.4.1/lib/tilt/haml.rb:24:in`evaluate'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/tilt-1.4.1/lib/tilt/template.rb:103:in `render'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/git_stats-1.0.9/lib/git_stats/stats_view/template.rb:15:in`render'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/git_stats-1.0.9/lib/git_stats/stats_view/view_data.rb:18:in `render_partial'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/git_stats-1.0.9/templates/activity/by_date.haml:1:in`block in singletonclass'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/git_stats-1.0.9/templates/activity/by_date.haml:65527:in `instance_eval'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/git_stats-1.0.9/templates/activity/by_date.haml:65527:in`singletonclass'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/git_stats-1.0.9/templates/activity/by_date.haml:65525:in `__tilt_70177236667600'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/tilt-1.4.1/lib/tilt/template.rb:170:in`call'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/tilt-1.4.1/lib/tilt/template.rb:170:in `evaluate'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/tilt-1.4.1/lib/tilt/haml.rb:24:in`evaluate'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/tilt-1.4.1/lib/tilt/template.rb:103:in `render'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/git_stats-1.0.9/lib/git_stats/stats_view/template.rb:13:in`block in render'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/git_stats-1.0.9/templates/layout.haml:29:in `block in singletonclass'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/git_stats-1.0.9/templates/layout.haml:65527:in`instance_eval'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/git_stats-1.0.9/templates/layout.haml:65527:in `singletonclass'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/git_stats-1.0.9/templates/layout.haml:65525:in`__tilt_70177236667600'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/tilt-1.4.1/lib/tilt/template.rb:170:in `call'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/tilt-1.4.1/lib/tilt/template.rb:170:in`evaluate'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/tilt-1.4.1/lib/tilt/haml.rb:24:in `evaluate'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/tilt-1.4.1/lib/tilt/template.rb:103:in`render'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/git_stats-1.0.9/lib/git_stats/stats_view/template.rb:13:in `render'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/git_stats-1.0.9/lib/git_stats/stats_view/view.rb:15:in`block in render_all'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/git_stats-1.0.9/lib/git_stats/stats_view/view.rb:14:in `each'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/git_stats-1.0.9/lib/git_stats/stats_view/view.rb:14:in`render_all'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/git_stats-1.0.9/lib/git_stats/generator.rb:5:in `render_all'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/git_stats-1.0.9/lib/git_stats/cli.rb:15:in`generate'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/thor-0.18.1/lib/thor/command.rb:27:in `run'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/thor-0.18.1/lib/thor/invocation.rb:120:in`invoke_command'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/thor-0.18.1/lib/thor.rb:363:in `dispatch'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/thor-0.18.1/lib/thor/base.rb:439:in`start'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/gems/git_stats-1.0.9/bin/git_stats:10:in `<top (required)>'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/bin/git_stats:19:in`load'
    from /Users/charliewu/.rvm/gems/ruby-1.9.3-p194/bin/git_stats:19:in `<main>'
