### PR TITLE
Switched short commit SHA to full SHA to remove ambiguity

### DIFF
--- a/lib/git_stats/git_data/repo.rb
+++ b/lib/git_stats/git_data/repo.rb
@@ -50,7 +50,7 @@ module GitStats
       end
 
       def commits
-        @commits ||= run_and_parse("git rev-list --pretty=format:'%h|%at|%ai|%aE' #{commit_range} #{tree_path} | grep -v commit").map do |commit_line|
+        @commits ||= run_and_parse("git rev-list --pretty=format:'%H|%at|%ai|%aE' #{commit_range} #{tree_path} | grep -v commit").map do |commit_line|
           Commit.new(
               repo: self,
               sha: commit_line[:sha],


### PR DESCRIPTION
Short SHA's are causing ambiguity problem in most of the cases for mid to large repo sizes. Git Stats fails there returning 0 insertions and 0 deletions for that commit. Following is a screenshot of the command run locally on a repo:

![screenshot from 2016-02-11 12_39_18](https://cloud.githubusercontent.com/assets/4680044/12971278/1c7647e0-d0bf-11e5-8f07-c378f3377cb4.png)

The line in issue is this: [Go to file at that line number](https://github.com/tomgi/git_stats/blob/master/lib/git_stats/git_data/repo.rb#L53)

I switched the small `h` giving short hash to `H` which gives full commit SHA which works fine and removes the ambiguity.
