### PR TITLE
quote unescaped ampersand at the beginning of a translation entry

### DIFF
--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -50,7 +50,7 @@ es:
   insertions: L&iacute;neas a&ntilde;adidas
   deletions: L&iacute;neas eliminadas
   first_commit: Primer commit
-  last_commit: &Uacute;ltimo commit
+  last_commit: '&Uacute;ltimo commit'
   author: Autor
   show_more: Mostrar m&aacute;s
   close: Cerrar


### PR DESCRIPTION
Without quoting the translation of "last commit", I had the following error when trying to run from git, apparently because an ampersand at the beginning of a yaml entry is special:

```
/usr/local/lib/ruby/gems/2.1.0/gems/i18n-0.7.0/lib/i18n/backend/base.rb:184:in `rescue in load_yml': can not load translations from /Users/nspring/cs/git_stats/config/locales/es.yml: #<Psych::SyntaxError: (/Users/nspring/cs/git_stats/config/locales/es.yml): did not find expected alphabetic or numeric character while scanning an anchor at line 53 column 16> (I18n::InvalidLocaleData)
	from /usr/local/lib/ruby/gems/2.1.0/gems/i18n-0.7.0/lib/i18n/backend/base.rb:181:in `load_yml'
	from /usr/local/lib/ruby/gems/2.1.0/gems/i18n-0.7.0/lib/i18n/backend/base.rb:165:in `load_file'
	from /usr/local/lib/ruby/gems/2.1.0/gems/i18n-0.7.0/lib/i18n/backend/base.rb:15:in `block in load_translations'
	from /usr/local/lib/ruby/gems/2.1.0/gems/i18n-0.7.0/lib/i18n/backend/base.rb:15:in `each'
	from /usr/local/lib/ruby/gems/2.1.0/gems/i18n-0.7.0/lib/i18n/backend/base.rb:15:in `load_translations'
	from /usr/local/lib/ruby/gems/2.1.0/gems/i18n-0.7.0/lib/i18n/backend/simple.rb:57:in `init_translations'
	from /usr/local/lib/ruby/gems/2.1.0/gems/i18n-0.7.0/lib/i18n/backend/simple.rb:40:in `available_locales'
	from /usr/local/lib/ruby/gems/2.1.0/gems/i18n-0.7.0/lib/i18n/config.rb:43:in `available_locales'
	from /usr/local/lib/ruby/gems/2.1.0/gems/i18n-0.7.0/lib/i18n/config.rb:49:in `available_locales_set'
	from /usr/local/lib/ruby/gems/2.1.0/gems/i18n-0.7.0/lib/i18n.rb:278:in `locale_available?'
	from /usr/local/lib/ruby/gems/2.1.0/gems/i18n-0.7.0/lib/i18n.rb:284:in `enforce_available_locales!'
	from /usr/local/lib/ruby/gems/2.1.0/gems/i18n-0.7.0/lib/i18n/config.rb:13:in `locale='
	from /usr/local/lib/ruby/gems/2.1.0/gems/i18n-0.7.0/lib/i18n.rb:35:in `locale='
	from /Users/nspring/cs/git_stats/lib/git_stats/cli.rb:17:in `generate'
	from /usr/local/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
	from /usr/local/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
	from /usr/local/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
	from /usr/local/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
	from ../../../../git_stats/bin/git_stats:10:in `<main>'

```