### PR TITLE
use --no-rename to ensure consistent behavior for shortspec on renamed files

### DIFF
--- a/lib/git_stats/git_data/commit.rb
+++ b/lib/git_stats/git_data/commit.rb
@@ -41,7 +41,7 @@ module GitStats
       end
 
       def lines_count
-        @lines_count ||= repo.run("git diff --shortstat `git hash-object -t tree /dev/null` #{self.sha} -- #{repo.tree_path}").lines.map do |line|
+        @lines_count ||= repo.run("git diff --shortstat --no-renames `git hash-object -t tree /dev/null` #{self.sha} -- #{repo.tree_path}").lines.map do |line|
           line[/(\d+) insertions?/, 1].to_i
         end.sum
       end

--- a/lib/git_stats/git_data/short_stat.rb
+++ b/lib/git_stats/git_data/short_stat.rb
@@ -19,7 +19,7 @@ module GitStats
 
       private
       def calculate_stat
-        stat_line = commit.repo.run("git show --shortstat --oneline #{commit.sha} -- #{commit.repo.tree_path}").lines.to_a[1]
+        stat_line = commit.repo.run("git show --shortstat --oneline --no-renames #{commit.sha} -- #{commit.repo.tree_path}").lines.to_a[1]
         if stat_line.blank?
           @files_changed = @insertions = @deletions = 0
         else

--- a/spec/git_data/short_stat_spec.rb
+++ b/spec/git_data/short_stat_spec.rb
@@ -14,7 +14,7 @@ describe GitStats::GitData::ShortStat do
           {content: '', expect: [0, 0, 0]},
       ].each do |test|
         it "#{test[:content]} parsing" do
-          commit.repo.should_receive(:run).with("git show --shortstat --oneline abc -- .").and_return("abc some commit\n#{test[:content]}")
+          commit.repo.should_receive(:run).with("git show --shortstat --oneline --no-renames abc -- .").and_return("abc some commit\n#{test[:content]}")
 
 
           commit.short_stat.should be_a(GitStats::GitData::ShortStat)


### PR DESCRIPTION
Running tests failed on my mac because git --shortstat reported a renamed file as a single file change with no insertions or deletions, while the spec file expected five lines added and five lines deleted.  It appears to be a feature of git 2.9 that it enables renaming detection by default.  

https://blog.bitbucket.org/2016/06/13/git-2-9/

Adding --no-renames to the git line ensures behavior consistent with what the test expects.

I don't know whether adding this option could cause trouble (it did not break on a git 2.1.4 on linux, but I haven't found where I can trace the command line options), or whether the correct answer is to force rename detection (replacing these --no-renames with --find-renames and updating the spec file).