### PR TITLE
Revert "Add files/lines by extension by date"

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -61,5 +61,3 @@ en:
   insertions_by_date: Lines added by date
   deletions_by_date: Lines deleted by date
   changed_lines_by_date: Changed lines by date
-  lines_by_extension_by_date: Lines per extension by date
-  files_by_extension_by_date: Files per extension by date

--- a/lib/git_stats/stats_view/charts/charts.rb
+++ b/lib/git_stats/stats_view/charts/charts.rb
@@ -3,7 +3,7 @@ module GitStats
   module StatsView
     module Charts
       class All
-        delegate :files_by_extension, :files_by_extension_by_date, :lines_by_extension, :lines_by_extension_by_date, :files_by_date, :lines_by_date, :comments_by_date, to: :repo_charts
+        delegate :files_by_extension, :lines_by_extension, :files_by_date, :lines_by_date, :comments_by_date, to: :repo_charts
 
         delegate :commits_sum_by_author_by_date, :changed_lines_by_author_by_date,
                  :insertions_by_author_by_date, :deletions_by_author_by_date, to: :authors_charts

--- a/lib/git_stats/stats_view/charts/repo_charts.rb
+++ b/lib/git_stats/stats_view/charts/repo_charts.rb
@@ -27,26 +27,6 @@ module GitStats
           end
         end
 
-        def files_by_extension_by_date
-          Chart.new do |f|
-            f.multi_date_chart(
-                data: @repo.files_by_extension_by_date,
-                title: :files_by_extension_by_date.t,
-                y_text: :files.t
-            )
-          end
-        end
-
-        def lines_by_extension_by_date
-          Chart.new do |f|
-            f.multi_date_chart(
-                data: @repo.lines_by_extension_by_date,
-                title: :lines_by_extension_by_date.t,
-                y_text: :files.t
-            )
-          end
-        end
-
         def files_by_date
           Chart.new do |f|
             f.date_chart(

--- a/templates/files/_files.haml
+++ b/templates/files/_files.haml
@@ -4,8 +4,6 @@
       %a{:href => 'by_date.html'}= :files_by_date.t
     %li{class: page == :files_by_extension ? "active" : ""}
       %a{:href => 'by_extension.html'}= :files_by_extension.t
-    %li{class: page == :files_by_extension_by_date ? "active" : ""}
-      %a{:href => 'by_extension_by_date.html'}= :files_by_extension_by_date.t
 
   .tab-content
     .tab-pane.active
@@ -15,5 +13,3 @@
         = high_stock("files_by_date", charts.files_by_date)
       - elsif page == :files_by_extension
         = high_chart("files_by_extension", charts.files_by_extension)
-      - elsif page == :files_by_extension_by_date
-        = high_stock("files_by_extension_by_date", charts.files_by_extension_by_date)

--- a/templates/files/by_extension_by_date.haml
+++ b/templates/files/by_extension_by_date.haml
@@ -1,1 +1,0 @@
-= render_partial('files/_files', page: :files_by_extension_by_date)

--- a/templates/lines/_lines.haml
+++ b/templates/lines/_lines.haml
@@ -4,8 +4,6 @@
       %a{:href => 'by_date.html'}= :lines_by_date.t
     %li{class: page == :lines_by_extension ? "active" : ""}
       %a{:href => 'by_extension.html'}= :lines_by_extension.t
-    %li{class: page == :lines_by_extension_by_date ? "active" : ""}
-      %a{:href => 'by_extension_by_date.html'}= :lines_by_extension_by_date.t
 
   .tab-content
     .tab-pane.active
@@ -15,5 +13,3 @@
         = high_stock("lines_by_date", charts.lines_by_date)
       - elsif page == :lines_by_extension
         = high_chart("lines_by_extension", charts.lines_by_extension)
-      - elsif page == :lines_by_extension_by_date
-        = high_stock("lines_by_extension_by_date", charts.lines_by_extension_by_date)

--- a/templates/lines/by_extension_by_date.haml
+++ b/templates/lines/by_extension_by_date.haml
@@ -1,1 +1,0 @@
-= render_partial('lines/_lines', page: :lines_by_extension_by_date)


### PR DESCRIPTION
This reverts commit 9005f4d0d07ee81efd5313f9f9faae6791d6dd60.
It was causing `git_stats` to use all the memory and crash on big repositories.
For now I will just remove this functionality and when I find time I will add command line argument to enable/disable it.

Calling @codebreach because you were the original author of this change.