### PR TITLE
Update ruby version used on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 rvm:
-  - "2.2.5"
+  - 2.2
+  - 2.3
+  - 2.4
   - ruby-head
 script:
   - bundle exec rake


### PR DESCRIPTION
 - Use 2.2 instead of 2.2.5 for the latest v2.2.x
 - Add more versions including v2.3, v2.4
  