### PR TITLE
tree_path bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ It browses the repository and outputs html page with statistics.
       t, [--last-commit-sha=LAST_COMMIT_SHA]    # Commit where statistics should stop.
                                                 # Default: HEAD
       s, [--silent], [--no-silent]              # Silent mode. Don't output anything.
-      d, [--tree=TREE]                          # Tree where statistics should be generated.
+      d, [--tree_path=TREE]                     # Tree where statistics should be generated.
                                                 # Default: .
       c, [--comment-string=COMMENT_STRING]      # The string which is used for comments.
                                                 # Default: //

--- a/lib/git_stats/cli.rb
+++ b/lib/git_stats/cli.rb
@@ -9,7 +9,7 @@ class GitStats::CLI < Thor
   option :first_commit_sha, :aliases => :f, :desc => 'Commit from where statistics should start.'
   option :last_commit_sha, :aliases => :t, :default => 'HEAD', :desc => 'Commit where statistics should stop.'
   option :silent, :aliases => :s, :type => :boolean, :desc => 'Silent mode. Don\'t output anything.'
-  option :tree, :aliases => :d, :default => '.', :desc => 'Tree where statistics should be generated.'
+  option :tree_path, :aliases => :d, :default => '.', :desc => 'Tree where statistics should be generated.'
   option :comment_string, :aliases => :c, :default => '//', :desc => 'The string which is used for comments.'
   
   desc 'generate', 'Generates the statistics of a repository'


### PR DESCRIPTION
Code throughout (repo, commits, etc) references tree_path. We could go and replace that all, but I think it's better to just shift the CLI param

Tested this and it works.

Honestly, I think that variable name is confusing. Git has trees, whereas no matter your operating system - directories are "directories". Or perhaps "path".