### PR TITLE
Allow specifying authors

### DIFF
--- a/lib/git_stats/git_data/repo.rb
+++ b/lib/git_stats/git_data/repo.rb
@@ -27,6 +27,10 @@ module GitStats
         @last_commit_sha ||= 'HEAD'
       end
 
+      def author_emails
+        @author_emails ||= []
+      end
+
       def tree_path
         @tree_path ||= '.'
       end
@@ -40,21 +44,25 @@ module GitStats
       end
 
       def authors
-        @authors ||= run_and_parse("git shortlog -se #{commit_range} #{tree_path}").map do |author|
-          Author.new(repo: self, name: author[:name], email: author[:email])
-        end
+        emails = author_emails.map { |email| email.downcase }
+        @authors ||= run_and_parse("git shortlog -se #{commit_range} #{tree_path}")
+          .select { |author| emails.count == 0 ? true : emails.include?(author[:email].downcase) }
+          .map { |author| Author.new(repo: self, name: author[:name], email: author[:email]) }
       end
 
       def commits
-        @commits ||= run_and_parse("git rev-list --pretty=format:'%H|%at|%ai|%aE' #{commit_range} #{tree_path} | grep -v commit").map do |commit_line|
-          Commit.new(
+        emails = author_emails.map { |email| email.downcase }
+        @commits ||= run_and_parse("git rev-list --pretty=format:'%H|%at|%ai|%aE' #{commit_range} #{tree_path} | grep -v commit")
+        .select { |commit_line| emails.include?(commit_line[:author_email].downcase) }
+        .map { |commit_line| Commit.new(
               repo: self,
               sha: commit_line[:sha],
               stamp: commit_line[:stamp],
               date: DateTime.parse(commit_line[:date]),
               author: authors.first! { |a| a.email == commit_line[:author_email] }
           )
-        end.sort_by! { |e| e.date }
+        }
+        .sort_by! { |e| e.date }
       end
 
       def commits_period


### PR DESCRIPTION
This allows the user to limit stats to specific email addresses to decrease the time it takes to generate stats.